### PR TITLE
Update README to instruct users to close Steam before launching injector

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,7 +10,7 @@ Usage
 
 Save the mod files in a non-system directory. It could be "Program Files", or "My Documents", or anything else as long as no special permissions are required to access that direcotry. If you're using a pre-packaged release, please unzip it rather than launching the mod from within the zip.
 
-Run "aliasIsolationInjectorGui.exe", and follow the displayed instructions. Once you press the "Launch Alien: Isolation" button, the mod launches Alien: Isolation and hooks into it. Exiting the app will remove the mod from the Alien. If the game is a Steam copy, the mod will inject itself into it Steam well, and then launch the game.
+Run "aliasIsolationInjectorGui.exe", and follow the displayed instructions. Once you press the "Launch Alien: Isolation" button, the mod launches Alien: Isolation and hooks into it. Exiting the app will remove the mod from the Alien. If the game is a Steam copy, first exit Steam before running the injector. If Steam is running before the injector is launched, it will not work. The mod will inject itself into it Steam well, and then launch the game.
 
 Injection into Steam is necessary, as it is actually the Steam.exe process which launches the game. Even if AI.exe is started directly, it communicates with Steam, and then exits immediately, allowing Steam to launch it. In order to hook into the game, Alias Isolation hooks into Steam, and intercepts its CreateProcessW call, subsequently injecting itself into the child process. The only binaries that are injected into are Steam.exe and AI.exe.
 


### PR DESCRIPTION
I downloaded the injector for the first time today and could not get it working with my Steam copy by following the README. I discovered that Steam must be closed before launching the game through the GUI injector in order for it to work. It looks like there is at least [one issue](https://github.com/aliasIsolation/aliasIsolation/issues/26) where the user was confused and this was the solution, so I really think this should be in the README.

Thanks for the hard work!